### PR TITLE
changement option --no-check-certificate 

### DIFF
--- a/raspberry_pi3/install_wifi_direct_rpi3.sh
+++ b/raspberry_pi3/install_wifi_direct_rpi3.sh
@@ -1,22 +1,22 @@
 #!/bin/sh 
-## wget -P --no-check-certificate /home/pirate https://raw.githubusercontent.com/jancelin/rpi_wifi_direct/master/raspberry_pi3/install_wifi_direct_rpi3.sh; chmod +x /home/pirate/install_wifi_direct_rpi3.sh; bash -x /home/pirate/install_wifi_direct_rpi3.sh
+## wget --no-check-certificate -P /home/pirate https://raw.githubusercontent.com/jancelin/rpi_wifi_direct/master/raspberry_pi3/install_wifi_direct_rpi3.sh; chmod +x /home/pirate/install_wifi_direct_rpi3.sh; bash -x /home/pirate/install_wifi_direct_rpi3.sh
 
 
 sudo apt-get update && 
 sudo apt-get upgrade &&
 sudo apt-get install dnsmasq hostapd &&
-wget -P --no-check-certificate /etc https://raw.githubusercontent.com/jancelin/rpi_wifi_direct/master/raspberry_pi3/dhcpcd.conf &&
-wget -P --no-check-certificate /etc/network/interfaces.d https://raw.githubusercontent.com/jancelin/rpi_wifi_direct/master/raspberry_pi3/wlan0 &&
+wget --no-check-certificate -P /etc https://raw.githubusercontent.com/jancelin/rpi_wifi_direct/master/raspberry_pi3/dhcpcd.conf &&
+wget --no-check-certificate -P /etc/network/interfaces.d https://raw.githubusercontent.com/jancelin/rpi_wifi_direct/master/raspberry_pi3/wlan0 &&
 sudo service dhcpcd restart &&
 sudo ifdown wlan0; sudo ifup wlan0 &&
-wget -P --no-check-certificate /etc/hostapd https://raw.githubusercontent.com/jancelin/rpi_wifi_direct/master/raspberry_pi3/hostapd.conf &&
+wget --no-check-certificate -P /etc/hostapd https://raw.githubusercontent.com/jancelin/rpi_wifi_direct/master/raspberry_pi3/hostapd.conf &&
 #sudo /usr/sbin/hostapd /etc/hostapd/hostapd.conf 
 mv /etc/default/hostapd /etc/default/hostapd.bak &&
-wget -P --no-check-certificate /etc/default https://raw.githubusercontent.com/jancelin/rpi_wifi_direct/master/raspberry_pi3/hostapd &&
+wget --no-check-certificate -P /etc/default https://raw.githubusercontent.com/jancelin/rpi_wifi_direct/master/raspberry_pi3/hostapd &&
 sudo mv /etc/dnsmasq.conf /etc/dnsmasq.conf.orig &&
-wget -P --no-check-certificate /etc https://raw.githubusercontent.com/jancelin/rpi_wifi_direct/master/raspberry_pi3/dnsmasq.conf &&
+wget --no-check-certificate -P /etc https://raw.githubusercontent.com/jancelin/rpi_wifi_direct/master/raspberry_pi3/dnsmasq.conf &&
 sudo mv /etc/sysctl.conf /etc/sysctl.conf.bak &&
-wget -P --no-check-certificate /etc https://raw.githubusercontent.com/jancelin/rpi_wifi_direct/master/raspberry_pi3/sysctl.conf &&
+wget --no-check-certificate -P /etc https://raw.githubusercontent.com/jancelin/rpi_wifi_direct/master/raspberry_pi3/sysctl.conf &&
 sudo sh -c "echo 1 > /proc/sys/net/ipv4/ip_forward" &&
 sleep 5
 sudo iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE  
@@ -25,10 +25,7 @@ sudo iptables -A FORWARD -i wlan0 -o eth0 -j ACCEPT
 sleep 5
 sudo sh -c "iptables-save > /etc/iptables.ipv4.nat" &&
 sudo mv /etc/rc.local /etc/rc.local.bak &&
-wget -P --no-check-certificate /etc https://raw.githubusercontent.com/jancelin/rpi_wifi_direct/master/raspberry_pi3/rc.local &&
+wget --no-check-certificate -P /etc https://raw.githubusercontent.com/jancelin/rpi_wifi_direct/master/raspberry_pi3/rc.local &&
 chmod +x  /etc/rc.local &&
 sudo service hostapd start 
 sudo service dnsmasq start
-
-
-


### PR DESCRIPTION
J'ai changé l'organisation des options --no-check-certificate et -P 
dans le script 
Dans le sens précédent, cela créait un fichier "--no-check-certificate"
![bureau](https://cloud.githubusercontent.com/assets/3932557/18955637/87aa8ebe-8658-11e6-8df8-4a2e7cf94834.png)

D'ailleurs, ce fameux fichier pour le supprimer, il faut faire:
`rm -r -- --no-check-certificate`
# 

I changed the way the options --no-check-certificate and -P were organized in the script
