### PR TITLE
Adding USB0 to route automatically web connection from Raspi Access Point

### DIFF
--- a/raspberry_pi3/install_wifi_direct_rpi3.sh
+++ b/raspberry_pi3/install_wifi_direct_rpi3.sh
@@ -20,8 +20,11 @@ sudo wget --no-check-certificate -P /etc https://raw.githubusercontent.com/jance
 sudo sh -c "echo 1 > /proc/sys/net/ipv4/ip_forward" &&
 sleep 5
 sudo iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE  
+sudo iptables -t nat -A POSTROUTING -o usb0 -j MASQUERADE  
 sudo iptables -A FORWARD -i eth0 -o wlan0 -m state --state RELATED,ESTABLISHED -j ACCEPT  
+sudo iptables -A FORWARD -i usb0 -o wlan0 -m state --state RELATED,ESTABLISHED -j ACCEPT  
 sudo iptables -A FORWARD -i wlan0 -o eth0 -j ACCEPT 
+sudo iptables -A FORWARD -i wlan0 -o usb0 -j ACCEPT 
 sleep 5
 sudo sh -c "iptables-save > /etc/iptables.ipv4.nat" &&
 #sudo mv /etc/rc.local /etc/rc.local.bak &&

--- a/raspberry_pi3/iptables.ipv4.nat
+++ b/raspberry_pi3/iptables.ipv4.nat
@@ -9,6 +9,7 @@
 -A OUTPUT ! -d 127.0.0.0/8 -m addrtype --dst-type LOCAL -j DOCKER
 -A POSTROUTING -s 172.17.0.0/16 ! -o docker0 -j MASQUERADE
 -A POSTROUTING -o eth0 -j MASQUERADE
+-A POSTROUTING -o usb0 -j MASQUERADE
 -A DOCKER -i docker0 -j RETURN
 COMMIT
 # Completed on Wed Jun 13 11:53:35 2018
@@ -28,6 +29,8 @@ COMMIT
 -A FORWARD -i docker0 -o docker0 -j ACCEPT
 -A FORWARD -i eth0 -o wlan0 -m state --state RELATED,ESTABLISHED -j ACCEPT
 -A FORWARD -i wlan0 -o eth0 -j ACCEPT
+-A FORWARD -i usb0 -o wlan0 -m state --state RELATED,ESTABLISHED -j ACCEPT
+-A FORWARD -i wlan0 -o usb0 -j ACCEPT
 -A DOCKER-ISOLATION -j RETURN
 -A DOCKER-USER -j RETURN
 COMMIT


### PR DESCRIPTION
3 lines to add USB0 to the configuration :+1: 
sudo iptables -t nat -A POSTROUTING -o usb0 -j MASQUERADE  
sudo iptables -A FORWARD -i usb0 -o wlan0 -m state --state RELATED,ESTABLISHED -j ACCEPT  
sudo iptables -A FORWARD -i wlan0 -o usb0 -j ACCEPT

